### PR TITLE
Fix qoiconv for windows

### DIFF
--- a/src/qoibench.cpp
+++ b/src/qoibench.cpp
@@ -39,7 +39,6 @@
 #include<filesystem>
 #include<string_view>
 #include<ranges>
-#include<fstream>
 #include<cstddef>
 #include<vector>
 #include<memory>

--- a/src/qoiconv.cpp
+++ b/src/qoiconv.cpp
@@ -35,13 +35,13 @@
 
 static inline std::vector<std::byte> load_file(const std::filesystem::path& path){
   std::vector<std::byte> bytes(std::filesystem::file_size(path));
-  std::ifstream ifs{path};
+  std::ifstream ifs{path, std::ios::binary};
   ifs.read(reinterpret_cast<char*>(bytes.data()), bytes.size());
   return bytes;
 }
 
 static inline void save_file(const std::filesystem::path& path, const std::vector<std::byte>& bytes){
-  std::ofstream ofs{path};
+  std::ofstream ofs{path, std::ios::binary};
   ofs.write(reinterpret_cast<const char*>(bytes.data()), bytes.size());
 }
 


### PR DESCRIPTION
To read/write binary data, we must specify `std::ios::binary` ...